### PR TITLE
Refactor OAuthProvider class

### DIFF
--- a/findaconf/blueprints/site/templates/login.slim
+++ b/findaconf/blueprints/site/templates/login.slim
@@ -6,11 +6,11 @@
     .small-7.columns
       form method="post" action="/login/process" id="login_form"
         .row
-          - for provider in providers.get_slugs()
-            div class="login_button {{ provider }} small-6 columns {% if loop.last %} end{% endif %}"
-              a data-oauth="{{ provider }}" title="Login with {{ providers.get_name(provider) }}"
-                %i class="fi-social-{{ provider }}"
-                span Log in with {{ providers.get_name(provider) }}
+          - for provider in providers
+            div class="login_button {{ provider.slug }} small-6 columns {% if loop.last %} end{% endif %}"
+              a data-oauth="{{ provider.slug }}" title="Login with {{ provider.name }}"
+                %i class="fi-social-{{ provider.slug }}"
+                span Log in with {{ provider.name }}
         .row
           .small-12.columns
             {{ form.hidden_tag() }}

--- a/findaconf/forms.py
+++ b/findaconf/forms.py
@@ -4,9 +4,10 @@ from wtforms import BooleanField, HiddenField
 from wtforms.validators import AnyOf
 
 providers = OAuthProvider()
+credentials = dict(providers.credentials)
 
 
 class LoginForm(Form):
     remember_me = BooleanField('Remember me (for a month)')
     provider = HiddenField(default='google-plus',
-                           validators=[AnyOf(providers.get_slugs())])
+                           validators=[AnyOf(credentials.keys())])

--- a/findaconf/helpers/providers.py
+++ b/findaconf/helpers/providers.py
@@ -5,63 +5,62 @@ from findaconf import app
 
 class OAuthProvider(object):
 
+    """
+    Loads oauth/oauth2 credentials from app.config['OAUTH_CREDENTIALS'] and
+    sets the following attributes:
+
+    * original: (dictionary) the same credentials as loaded
+
+    * credentials: (list generator) tuples (slug, credentials) for a filtered
+    version of the loaded credentials keeping only `valid` oauth/oauth2
+    providers, i.e. the ones  with client key and secret properly set
+
+    * ordered: (list generator) OAuthProvider object for each valid
+    provider (sorted alphabetically)
+    """
+
     def __init__(self):
+        self.original = app.config['OAUTH_CREDENTIALS']
+
+    @property
+    def credentials(self):
         """
-        Loads oauth/oauth2 credentials from app.config['OAUTH_CREDENTIALS'] and
-        sets the following instance attributes:
-
-        * original_credentials: (dictionary) the same credentials as loaded
-
-        * credentials: (dictionary) filtered version of the loaded credentials
-        keeping only `valid` oauth/oauth2 providers, i.e. the ones  with client
-        key and secret properly set
-
-        * names: (list) humanized names for valid oauth/oauth2 providers (e.g.
-        Google Plus instead of google-plus)
-
-        * slugs: (list) slugs for valid oauth/oauth2 providers (e.g.
-        google-plus instead of Google Plus)
-
-        * providers: (dictionary) valid oauth/oauth2 providers having the slug
-        as key and the humanized name as value
+        Test each oauth/oauth2 provider to check if it has client and secret
+        keys set, and deleteing the ones with no settings. Returns a list
+        generator with tuples (provider name, provider settings).
         """
+        for provider in self.original.iterkeys():
+            credentials = self.original.get(provider)
+            if credentials:
+                key = credentials.get('consumer_key')
+                secret = credentials.get('consumer_secret')
+                if key and secret:
+                    provider = ProviderUI(name=provider)
+                    yield provider.slug, self.original[provider.name]
 
-        # load credentials & check if consumer key an secret are set
-        self.original_credentials = app.config['OAUTH_CREDENTIALS']
-        self.credentials = dict()
-        for provider in self.original_credentials.keys():
-            if self.__valid_provider(provider):
-                credential = self.original_credentials[provider]
-                self.credentials[provider] = credential
+    @property
+    def ordered(self):
+        """ List generator with OAuthProvider objects ordered by name  """
+        credentials = dict(self.credentials)
+        names = sorted([name for name in credentials.iterkeys()])
+        for name in names:
+            yield ProviderUI(name=name) 
+            
+    def name(self, slug):
+        """Returns a provider name given its slug"""
+        for provider in self.ordered:
+            if provider.slug == slug:
+                return provider.name
+        return None
 
-        # set support vars
-        self.names = sorted([p for p in self.credentials])
-        self.slugs = [p.lower().replace(' ', '-') for p in self.names]
-        self.providers = dict(zip(self.slugs, self.names))
+        
+class ProviderUI(object):
 
-    def __valid_provider(self, provider_name):
-        """
-        Test if a oauth/oauth2 provider is valid by asserting it has the client
-        key and secret set.
-        :param provider_name: (string) humanized name (e.g. Google Plus instead
-        of google-plus) of a oauth/oauth2 provider
-        :return: (boolean) True if valid, False otherwise
-        """
-        credentials = self.original_credentials.get(provider_name, None)
-        if credentials:
-            key = credentials.get('consumer_key', None)
-            secret = credentials.get('consumer_secret', None)
-            if key and secret:
-                return True
-        return False
+    """ Creates a  object with name & slug for oauth/oauth2 providers"""
+    
+    def __init__(self, name=None):
+        self.name = name
 
-    def get_name(self, provider_slug):
-        """
-        Returns the humanized name for a valid oauth/oauth2 provider.
-        :param provide_slug: (string) slug for a valid oauth/oauth2 provider
-        :return: (string|None) humanized name of a valid oauth/oauth2 provider
-        """
-        return str(self.providers.get(provider_slug, None))
-
-    def get_slugs(self):
-        return [str(slug) for slug in self.slugs]
+    @property
+    def slug(self):
+        return self.name.lower().replace(' ', '-')

--- a/findaconf/helpers/providers.py
+++ b/findaconf/helpers/providers.py
@@ -35,17 +35,18 @@ class OAuthProvider(object):
                 key = credentials.get('consumer_key')
                 secret = credentials.get('consumer_secret')
                 if key and secret:
-                    provider = ProviderUI(name=provider)
-                    yield provider.slug, self.original[provider.name]
+                    ui = ProviderUI(name=provider)
+                    self.original[provider]['ui'] = ui
+                    yield ui.slug, self.original[provider]
 
     @property
     def ordered(self):
-        """ List generator with OAuthProvider objects ordered by name  """
+        """ List generator with OAuthProvider objects ordered by slug """
         credentials = dict(self.credentials)
-        names = sorted([name for name in credentials.iterkeys()])
-        for name in names:
-            yield ProviderUI(name=name) 
-            
+        slugs = sorted([slug for slug in credentials.iterkeys()])
+        for slug in slugs:
+            yield credentials[slug]['ui'] 
+
     def name(self, slug):
         """Returns a provider name given its slug"""
         for provider in self.ordered:

--- a/findaconf/models.py
+++ b/findaconf/models.py
@@ -4,7 +4,6 @@ import re
 from findaconf import db
 from flask.ext.login import UserMixin
 from hashlib import md5, sha512
-from os import urandom
 from uuid import uuid4
 
 conferences_keywords = db.Table(

--- a/findaconf/tests/test_site_routes.py
+++ b/findaconf/tests/test_site_routes.py
@@ -119,11 +119,6 @@ class TestSiteRoutes(TestCase):
     @patch('findaconf.blueprints.site.views.Authomatic', autospec=True)
     def test_unsuccessful_user_login_with_invalid_email(self, mocked):
 
-        # get a valid login link/provider
-        providers = OAuthProvider()
-        valid_providers = providers.get_slugs()
-        self.assertTrue(valid_providers)
-
         # create a mock object for Authomatic.login() & try to login
         mocked.return_value = MockAuthomatic(email='fulano-de.tal')
         resp = self.app.get('/login/{}'.format(self.default_provider),
@@ -139,11 +134,6 @@ class TestSiteRoutes(TestCase):
 
     @patch('findaconf.blueprints.site.views.Authomatic', autospec=True)
     def test_unsuccessful_user_login_with_no_email(self, mocked):
-
-        # get a valid login link/provider
-        providers = OAuthProvider()
-        valid_providers = providers.get_slugs()
-        self.assertTrue(valid_providers)
 
         # create a mock object for Authomatic.login() & try to login
         mocked.return_value = MockAuthomatic(email=None)
@@ -188,11 +178,6 @@ class TestSiteRoutes(TestCase):
     @patch('findaconf.blueprints.site.views.Authomatic', autospec=True)
     def test_login_with_remember_me(self, mocked):
 
-        # get a valid login link/provider
-        providers = OAuthProvider()
-        valid_providers = providers.get_slugs()
-        self.assertTrue(valid_providers)
-
         # create a mock object for Authomatic.login()
         mocked.return_value = MockAuthomatic()
 
@@ -215,11 +200,6 @@ class TestSiteRoutes(TestCase):
 
     @patch('findaconf.blueprints.site.views.Authomatic', autospec=True)
     def test_returning_user_with_remember_me(self, mocked):
-
-        # get a valid login link/provider
-        providers = OAuthProvider()
-        valid_providers = providers.get_slugs()
-        self.assertTrue(valid_providers)
 
         # create a mock object for Authomatic.login()
         mocked.return_value = MockAuthomatic()
@@ -245,11 +225,6 @@ class TestSiteRoutes(TestCase):
 
     @patch('findaconf.blueprints.site.views.Authomatic', autospec=True)
     def test_failed_login_with_api_error(self, mocked):
-
-        # get a valid login link/provider
-        providers = OAuthProvider()
-        valid_providers = providers.get_slugs()
-        self.assertTrue(valid_providers)
 
         # error in HTML and parsed
         html = """


### PR DESCRIPTION
The previous `OAuthProvider()` class was too ugly, so I decided to make it more _pythonic_.

The code of `OAuthProvider()` is better now, but in general the readability of all other files using this class is actually the major enhancement (check the [login.slim](https://github.com/cuducos/findaconf/commit/43c478d18c4b89438210403d9ed199d131d0c527), for example).
